### PR TITLE
Generate link from same name based on locale

### DIFF
--- a/Entity/RouteRepository.php
+++ b/Entity/RouteRepository.php
@@ -111,9 +111,21 @@ class RouteRepository extends EntityRepository implements RouteRepositoryInterfa
     /**
      * {@inheritDoc}
      */
-    public function getRouteByName($name, $parameters = array())
+    public function getRouteByName($name, $parameters = array(), $config = array())
     {
-        $route = $this->findOneByName($name);
+	$locale = $config['locale'];
+        $defaultLocale = $config['defaultLocale'];
+	
+        $route = $this->findOneBy(array('name' => $name, 'locale' => $locale));
+
+        if (!$route) {
+            $route = $this->findOneBy(array('name' => $name, 'locale' => substr($locale, 0, 2)));
+        }
+
+        if (!$route) {
+            $route = $this->findOneBy(array('name' => $name, 'locale' => $defaultLocale));
+        }
+        
         if (!$route) {
             throw new RouteNotFoundException("No route found for name '$name'");
         }

--- a/Routing/Base/DynamicRouter.php
+++ b/Routing/Base/DynamicRouter.php
@@ -121,8 +121,9 @@ class DynamicRouter implements RouterInterface
             $route = $parameters['route'];
             unset($parameters['route']);
         } elseif ($name) {
-
-            $route = $this->routeRepository->getRouteByName($name, $parameters);
+	    $config['locale'] = $this->getLocale($parameters);
+            $config['defaultLocale'] = $this->container->getParameter('locale');
+            $route = $this->routeRepository->getRouteByName($name, $parameters, $config);
         } else {
             $route = $this->getRouteFromContent($parameters);
             unset($parameters['route']); // could be an empty string


### PR DESCRIPTION
Hi,

When using Translatable Doctrine Extensions, one can have multiple language versions of page at one route name. I propose to find routes not only by name but also by current locale. Also, if this search fails, fallback to 2-letter locale (user have en_US locale, but in DB en_EN is stored), and it the latter fails then fallback to default locale.

Best Regards,
Kacper
